### PR TITLE
fix: resolve session persistence — cookies not surviving proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ credentials*
 secrets*
 
 # IDE/Editor
-.vscode/
+.vscode/settings.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "API: Debug",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["--import", "tsx", "--inspect=9229"],
+      "args": ["src/index.ts"],
+      "cwd": "${workspaceFolder}/apps/api",
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "restart": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
+    },
+    {
+      "name": "API: Attach",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**", "**/node_modules/**"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Full Stack: Debug",
+      "configurations": ["API: Debug"],
+      "preLaunchTask": "Web: dev",
+      "stopAll": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,72 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "API: dev",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["--filter", "@gemtest/api", "dev"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "dev",
+        "reveal": "always",
+        "panel": "dedicated",
+        "showReuseMessage": false
+      }
+    },
+    {
+      "label": "Web: dev",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["--filter", "@gemtest/web", "dev"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "dev",
+        "reveal": "always",
+        "panel": "dedicated",
+        "showReuseMessage": false
+      }
+    },
+    {
+      "label": "Dev: Start All",
+      "dependsOn": ["API: dev", "Web: dev"],
+      "dependsOrder": "parallel",
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "default"
+      }
+    },
+    {
+      "label": "API: debug",
+      "type": "shell",
+      "command": "node",
+      "args": [
+        "--import", "tsx",
+        "--inspect=9229",
+        "src/index.ts"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/apps/api",
+        "env": {
+          "NODE_ENV": "development"
+        }
+      },
+      "isBackground": true,
+      "problemMatcher": [],
+      "presentation": {
+        "group": "debug",
+        "reveal": "always",
+        "panel": "dedicated",
+        "showReuseMessage": false
+      }
+    }
+  ]
+}

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,7 +4,7 @@ NODE_ENV=development
 
 # Auth.js
 AUTH_SECRET= # Run `npx auth secret` to generate one
-AUTH_URL=http://localhost:4000
+AUTH_URL=http://localhost:5173/api/auth  # Must match the browser origin (Vite proxy)
 
 # OAuth Providers
 GOOGLE_CLIENT_ID=

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -41,9 +41,10 @@ type ToWebRequestParams = {
 const toWebRequest = (params: ToWebRequestParams): Request => {
   const { req } = params
   // Always use the browser's perceived origin for Auth.js internal logic
-  const protocol: string = 'http'
-  const host: string = 'localhost:5173'
-  const url: string = `${protocol}://${host}${req.originalUrl}`
+  const browserOrigin: string = process.env.AUTH_URL
+    ? new URL(process.env.AUTH_URL).origin
+    : 'http://localhost:5173'
+  const url: string = `${browserOrigin}${req.originalUrl}`
 
   const headers: Headers = new Headers()
   Object.entries(req.headers).forEach(([key, value]): void => {
@@ -55,6 +56,9 @@ const toWebRequest = (params: ToWebRequestParams): Request => {
       headers.append(key, value)
     }
   })
+  // Ensure Host header matches the browser's origin so Auth.js
+  // generates correct cookies and callback URLs with trustHost: true
+  headers.set('host', new URL(browserOrigin).host)
 
   /**
    * Safe body retrieval checking for rawBody property.

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -12,6 +12,26 @@ import { type User } from '@gemtest/schema'
 import { type User as AuthUser } from '@auth/core/types'
 import { Result, fromPromise } from 'neverthrow'
 
+const isProduction: boolean = process.env.NODE_ENV === 'production'
+
+type CookieOptions = {
+  readonly httpOnly: boolean
+  readonly sameSite: 'lax'
+  readonly path: string
+  readonly secure: boolean
+}
+
+/**
+ * Shared cookie options for all Auth.js cookies.
+ * Ensures consistent behavior across session, callback, and CSRF tokens.
+ */
+const cookieOptions: CookieOptions = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  path: '/',
+  secure: isProduction,
+}
+
 type VerificationRequestParams = {
   readonly identifier: string
   readonly url: string
@@ -137,9 +157,26 @@ export const authConfig: AuthConfig = {
     }),
   ],
   session: {
-    strategy: 'database' as const,
+    // Credentials provider does not support 'database' strategy in Auth.js —
+    // it silently falls back to JWT but the session endpoint still queries
+    // the DB, returning null. Use 'jwt' until OAuth providers are added (#4).
+    strategy: 'jwt' as const,
   },
-  useSecureCookies: process.env.NODE_ENV === 'production',
+  useSecureCookies: isProduction,
+  cookies: {
+    sessionToken: {
+      name: 'authjs.session-token',
+      options: cookieOptions,
+    },
+    callbackUrl: {
+      name: 'authjs.callback-url',
+      options: cookieOptions,
+    },
+    csrfToken: {
+      name: 'authjs.csrf-token',
+      options: cookieOptions,
+    },
+  },
   callbacks: {
     /**
      * Enhances the session object with additional user metadata.
@@ -151,17 +188,29 @@ export const authConfig: AuthConfig = {
      * @param params - Object containing the current session and user entities.
      * @returns The augmented session object.
      */
-    // TODO: Replace with Auth.js module augmentation for Session type
+    // TODO: Replace with Auth.js module augmentation for Session type (#3)
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    session: async (params: {
-      readonly session: any
+    jwt: async (params: {
+      readonly token: any
       readonly user: any
     }): Promise<any> => {
+      const { token, user } = params
+      // On initial sign-in, copy user fields into the JWT payload
+      if (user) {
+        token.id = user.id
+        token.role = user.role
+      }
+      return token
+    },
+    session: async (params: {
+      readonly session: any
+      readonly token: any
+    }): Promise<any> => {
       /* eslint-enable @typescript-eslint/no-explicit-any */
-      const { session, user } = params
-      if (session.user) {
-        session.user.id = user.id
-        session.user.role = user.role
+      const { session, token } = params
+      if (session.user && token) {
+        session.user.id = token.id
+        session.user.role = token.role
       }
       return session
     },

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -65,7 +65,7 @@ test.describe('Authentication Flow', () => {
     await page.getByPlaceholder(/Email/i).fill(testUser.email)
     await page.getByPlaceholder(/Contraseña/i).fill(testUser.password)
     await page.getByRole('button', { name: /Acceder/i }).click()
-    
+
     // Force reload for stability
     await page.reload({ waitUntil: 'networkidle' })
 
@@ -75,7 +75,7 @@ test.describe('Authentication Flow', () => {
 
     // Click logout
     await logoutBtn.click()
-    
+
     // Force reload to ensure state sync
     await page.reload({ waitUntil: 'networkidle' })
 

--- a/apps/web/src/lib/apollo.ts
+++ b/apps/web/src/lib/apollo.ts
@@ -13,6 +13,7 @@ const uri: string = import.meta.env.VITE_API_URL || '/graphql'
 
 const link: HttpLink = new HttpLink({
   uri,
+  credentials: 'include',
 })
 
 /**

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -28,7 +28,7 @@ export const authConfig: NextAuthConfig = {
         // Mock de autenticación para esta fase
         const email = credentials?.email
         const password = credentials?.password
-        
+
         if (typeof email !== 'string' || typeof password !== 'string') {
           return null
         }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,16 +9,17 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    strictPort: true,
     proxy: {
       '/api/auth': {
         target: 'http://localhost:4000',
-        changeOrigin: true,
+        changeOrigin: false,
         secure: false,
         ws: true,
       },
       '/graphql': {
         target: 'http://localhost:4000',
-        changeOrigin: true,
+        changeOrigin: false,
         secure: false,
       },
     },

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -17,7 +17,7 @@ export const Button: React.FC<ButtonProps> = (
   props: ButtonProps,
 ): React.ReactElement => {
   const { onClick, children, className = '' }: ButtonProps = props
-  
+
   // Combine base styles with custom className
   const combinedClassName: string = `px-4 py-2 bg-indigo-600 text-white rounded-md 
     hover:bg-indigo-700 transition-colors ${className}`


### PR DESCRIPTION
## Summary

Closes #1

- **AUTH_URL mismatch**: pointed to backend (`localhost:4000`) instead of browser origin (`localhost:5173`), breaking CORS and Auth.js callback URLs
- **Vite proxy `changeOrigin: true`**: rewrote Host header to `:4000`, causing Auth.js with `trustHost` to generate cookies for the wrong origin
- **Session strategy**: `strategy: 'database'` silently fails with Credentials provider — Auth.js encodes a JWT but the session endpoint queries an empty DB table. Switched to `strategy: 'jwt'`
- **Apollo HttpLink**: missing `credentials: 'include'` — cookies were never sent with GraphQL requests
- **No explicit cookie config**: Auth.js defaults didn't guarantee `sameSite: lax` / `path: /` through the proxy

### Additional improvements
- `strictPort: true` in Vite to fail fast instead of silently switching ports
- VSCode `tasks.json` with split terminals for API/Web
- VSCode `launch.json` with debug configs (`--inspect`) for API backend
- `.vscode/` shared in git (only `settings.json` remains ignored)

## Files changed

| File | Change |
|------|--------|
| `apps/api/.env.example` | `AUTH_URL` → `localhost:5173/api/auth` |
| `apps/api/src/index.ts` | Dynamic `browserOrigin` + Host header override |
| `apps/api/src/lib/auth.ts` | JWT strategy, jwt+session callbacks, shared cookie config |
| `apps/web/src/lib/apollo.ts` | `credentials: 'include'` |
| `apps/web/vite.config.ts` | `changeOrigin: false`, `strictPort: true` |
| `.gitignore` | `.vscode/` → `.vscode/settings.json` |
| `.vscode/tasks.json` | Split terminal tasks |
| `.vscode/launch.json` | API debug launch configs |

## Test plan

- [x] `curl` login flow: CSRF → credentials POST → session check returns user data
- [x] Session persists across multiple requests
- [x] Manual browser test: register + login working
- [x] TypeScript compilation passes (no new errors)
- [x] Lint passes (no new errors)

Generated with [Claude Code](https://claude.com/claude-code)