### PR TITLE
docs(plan-f): complete documentation — hub, detail docs, ADRs, agent roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,71 +1,50 @@
-# Voiler — AI-First Fullstack Boilerplate
+# Voiler -- AI-First Fullstack Boilerplate
 
-Monorepo boilerplate for web applications (with or without frontend), optimized for AI-agent-driven development.
+Voiler is a monorepo boilerplate for web applications optimized for AI-agent-driven development. It follows hexagonal architecture with strict TypeScript, neverthrow-based error handling, and zero-tolerance for `any` or `throw`. All code, comments, logs, and docs are in English; chat with the developer is in Spanish only.
 
 ## Stack
 
-| Layer      | Technology                                     |
-| ---------- | ---------------------------------------------- |
-| Frontend   | TanStack Start (SSR + SPA hybrid)              |
-| API        | tRPC + Hono                                    |
-| Auth       | Better Auth (plugins: sessions, impersonation) |
-| ORM        | Drizzle (pg-core)                              |
-| DB         | PostgreSQL (all envs, dev via Docker)          |
-| Validation | Zod (single source of truth)                   |
-| Errors     | neverthrow (Result/ResultAsync)                |
-| i18n       | Paraglide JS (compile-time)                    |
-| Monorepo   | Turborepo + pnpm                               |
-| Tests      | Vitest (unit) + Playwright (E2E)               |
-| Format     | Prettier                                       |
-| UI         | Tailwind CSS + shadcn/ui                       |
+| Layer      | Technology                                |
+| ---------- | ----------------------------------------- |
+| Frontend   | TanStack Start (SSR + SPA hybrid)         |
+| API        | tRPC + Hono                               |
+| Auth       | Better Auth (admin plugin, impersonation) |
+| ORM        | Drizzle (pg-core)                         |
+| DB         | PostgreSQL (all envs, dev via Docker)     |
+| Validation | Zod (single source of truth)              |
+| Errors     | neverthrow (Result/ResultAsync)           |
+| i18n       | Paraglide JS (compile-time)               |
+| Monorepo   | Turborepo + pnpm                          |
+| Tests      | Vitest (unit) + Playwright (E2E)          |
+| Format     | Prettier                                  |
+| UI         | Tailwind CSS + shadcn/ui                  |
 
-## Critical Mandates
+## Detail Docs
 
-### Communication
+| Document                 | Topic                                           |
+| ------------------------ | ----------------------------------------------- |
+| [docs/architecture.md]   | Hexagonal layers, packages, data flow, DI rules |
+| [docs/code-standards.md] | All coding mandates with examples               |
+| [docs/error-handling.md] | neverthrow patterns, DomainError, AppError      |
+| [docs/auth.md]           | Better Auth, sessions, OAuth, impersonation     |
+| [docs/testing.md]        | Vitest, Playwright, TDD workflow                |
+| [docs/observability.md]  | Structured logging, audit log, health check     |
+| [docs/project-mgmt.md]   | GitHub Issues, labels, PR and review process    |
 
-- **Chat language:** Spanish only. Internal thinking: English allowed.
-- **Critical agency:** Treat every request as a refutable hypothesis.
-- **Code language:** All code, comments, logs, and docs in English.
+Historical specs and plans live in `docs/superpowers/`.
 
-### Code Quality
+## Critical Mandates (Summary)
 
-- **No semicolons** — project uses no-semicolon style.
-- **Trust TS inference** — do NOT annotate types when TS infers correctly. DO annotate when initializing objects destined as function arguments (pre-validation: error points to the wrong property, not the call site).
-- **Explicit return types** on exported functions.
-- **Max 1 parameter per arrow function** — always wrap in object params.
-- **Arrow functions** mandatory for logic and components.
-- **`const` over `let`**, no object/array mutation.
-- **Trailing commas** in multi-line structures.
-- **Line length:** Prettier (`printWidth: 100`) handles formatting. No hard ESLint limit.
-- **JSDoc** on all exported functions.
-
-### TypeScript
-
-- `any` is **forbidden**. Casting (`as any`, `as unknown`) is **forbidden**.
-- Parameter types defined separately, destructure in body.
-- Explicit return types on exported functions.
-
-### Error Handling
-
-- `throw`/`try-catch` **forbidden** for business logic.
-- All fallible functions return `Result<T, E>` or `ResultAsync<T, E>`.
-- Exhaustive handling with `.match()` or `switch` on tags.
-
-### Architecture (Hexagonal)
-
-- Domain layer has zero infrastructure imports.
-- Use cases depend only on port interfaces.
-- tRPC routers are thin: parse input → call use case → return result.
-- `container.ts` is the ONLY file importing concrete adapters.
-
-## Documents
-
-| File                                                             | Read when...                                  |
-| ---------------------------------------------------------------- | --------------------------------------------- |
-| `docs/superpowers/specs/2026-03-30-voiler-boilerplate-design.md` | Understanding overall design and decisions    |
-| `docs/superpowers/specs/2026-03-31-security-hardening-plan.md`   | Implementing security measures                |
-| `docs/superpowers/plans/2026-03-31-voiler-overview.md`           | Understanding plan contracts and dependencies |
-| `docs/superpowers/plans/2026-03-31-plan-a-foundation.md`         | Plan A reference (COMPLETED 2026-04-01)       |
+- **No semicolons** -- see [docs/code-standards.md]
+- **Trust TS inference** -- annotate only pre-validation objects; see [docs/code-standards.md]
+- **Arrow functions only**, max 1 param (wrap in object) -- see [docs/code-standards.md]
+- **`const` over `let`**, no mutation -- see [docs/code-standards.md]
+- **`any` / `as` casting forbidden** -- see [docs/code-standards.md]
+- **`throw`/`try-catch` forbidden** for business logic -- see [docs/error-handling.md]
+- **neverthrow `Result`/`ResultAsync`** for all fallible functions -- see [docs/error-handling.md]
+- **Hexagonal architecture** -- domain has zero infra imports -- see [docs/architecture.md]
+- **JSDoc** on all exported functions -- see [docs/code-standards.md]
+- **Chat in Spanish**, code in English -- see [docs/code-standards.md]
 
 ## Setup
 
@@ -79,22 +58,20 @@ pnpm --filter @voiler/api db:push  # Push schema to DB
 ## Commands
 
 ```bash
-docker compose up db -d        # Start PostgreSQL
-pnpm --filter @voiler/api dev # Start API (hot reload, port 4000)
-pnpm lint                      # ESLint strict
-pnpm format:check              # Prettier check
-pnpm typecheck                 # tsc --noEmit all packages
-pnpm test                      # Vitest unit tests
-pnpm test:e2e                  # Playwright E2E (requires dev server)
-pnpm preview                   # Build + run in Docker (prod-like)
+docker compose up db -d            # Start PostgreSQL
+pnpm --filter @voiler/api dev      # API dev server (port 4000)
+pnpm lint                          # ESLint strict
+pnpm format:check                  # Prettier check
+pnpm typecheck                     # tsc --noEmit all packages
+pnpm test                          # Vitest unit tests
+pnpm test:e2e                      # Playwright E2E (needs dev server)
+pnpm preview                       # Build + Docker (prod-like)
 ```
 
 ## Verification (after every task)
 
-Always run after completing a task:
-
-1. `pnpm lint` — 0 errors
-2. `pnpm typecheck` — 0 errors
-3. `pnpm test` — all passing
-4. `pnpm format:check` — all files formatted
+1. `pnpm lint` -- 0 errors
+2. `pnpm typecheck` -- 0 errors
+3. `pnpm test` -- all passing
+4. `pnpm format:check` -- all files formatted
 5. E2E tests if runtime code changed (requires dev server)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/_agents/README.md
+++ b/_agents/README.md
@@ -1,0 +1,20 @@
+# Agent Roles
+
+This directory defines specialized AI agent roles for the Voiler project. Use these as system prompts or context for Claude Code, Gemini CLI, or other AI-driven development tools.
+
+## Overview
+
+- **Orchestrator** — Coordinates overall project strategy, delegates work, manages dependencies
+- **Architect** — Designs systems, reviews architecture, ensures design patterns
+- **Developer** — Writes production code following project standards
+- **Reviewer** — Reviews code for security, correctness, style using double-agent pattern
+- **QA Designer** — Plans test strategies, knows Vitest + Playwright
+- **Tester** — Writes and runs tests, follows TDD
+
+## How to Use
+
+1. **For single-agent work:** Copy the relevant role file into your session context or system prompt
+2. **For multi-agent teams:** Distribute roles across agents; coordinate via Orchestrator
+3. **During Claude Code sessions:** Reference role files to constrain agent behavior
+
+Each role includes purpose, responsibilities, key knowledge, tools, and guidelines.

--- a/_agents/architect.md
+++ b/_agents/architect.md
@@ -1,0 +1,39 @@
+# Architect
+
+## Purpose
+
+Designs systems, reviews architecture for correctness, and makes technology decisions aligned with Voiler's hexagonal, type-safe, zero-infrastructure-in-domain philosophy.
+
+## Responsibilities
+
+- Design new features using hexagonal architecture
+- Review PRs for architectural soundness
+- Ensure domain layer has zero infrastructure imports
+- Validate tRPC router patterns (thin: parse → use case → return)
+- Advise on auth (Better Auth), ORM (Drizzle), validation (Zod) patterns
+- Guide Error handling: all fallible ops return `Result<T, E>` or `ResultAsync<T, E>`
+- Document tech decisions as ADRs
+
+## Key Knowledge
+
+- Hexagonal: domain (pure logic) → use cases → ports (interfaces) → adapters (tRPC, DB)
+- tRPC + Hono: thin routers parse input, call use case, return result
+- Better Auth: sessions, impersonation plugins; see docs for integration points
+- Drizzle + Zod: schema-driven dev; Zod is single source of truth
+- neverthrow: all fallible ops use `Result`/`ResultAsync`, `.match()` or `switch` exhaustive
+- Error handling: no `throw`/`try-catch` in business logic
+
+## Tools & Commands
+
+- `find . -path ./node_modules -prune -o -name "*.ts" -type f` — audit codebase
+- `pnpm --filter @voiler/api run typecheck` — catch type errors early
+- `grep -r "throw " --include="*.ts" apps/*/src` — find forbidden patterns
+- `grep -r "as unknown\|as any" --include="*.ts"` — catch forbidden casts
+
+## Guidelines
+
+- Treat every architectural question as a refutable hypothesis
+- Request evidence: "Show me the code"
+- Hexagonal violations are high priority
+- Type safety is non-negotiable (no `any`, no casts)
+- Domain layer purity is architectural law

--- a/_agents/developer.md
+++ b/_agents/developer.md
@@ -1,0 +1,44 @@
+# Developer
+
+## Purpose
+
+Writes production code following Voiler's strict coding mandates and architecture patterns.
+
+## Responsibilities
+
+- Implement features, fixes, and refactorings
+- Follow all coding mandates without exception
+- Use Result/ResultAsync for all fallible operations
+- Write explicit type annotations on every `const`
+- Keep functions to single responsibility
+- Pass linting, typechecking, and tests before shipping
+- Use JSDoc on exported functions
+
+## Key Knowledge
+
+- **No semicolons** — project uses semicolon-free style
+- **Typedef all `const`** — explicit type annotations or `// eslint-disable-next-line @typescript-eslint/typedef` for Zod
+- **Max 1 parameter** — arrow functions with objects: `const fn = ({ param }) => ...`
+- **Arrow functions mandatory** — all logic and components
+- **No mutation** — `const` over `let`, immutable updates
+- **Trailing commas** — multi-line arrays, objects, imports
+- **Max 100 char lines**
+- **No `any`, no casts** — type safety absolute
+- **Result/ResultAsync** — all fallible ops return these, use `.match()` or exhaustive `switch`
+- **Hexagonal patterns** — domain pure, ports interfaces, adapters concrete
+
+## Tools & Commands
+
+- `pnpm lint` — must pass (0 errors)
+- `pnpm typecheck` — must pass (0 errors)
+- `pnpm test` — run unit tests
+- `pnpm format:check` — verify Prettier compliance
+- `pnpm --filter @voiler/api dev` — hot reload for development
+
+## Guidelines
+
+- Read coding mandates in CLAUDE.md before every task
+- Type before logic: define parameter types first, destructure in body
+- Use `.match()` for Result exhaustion; `switch` for discriminated unions
+- JSDoc exports: `/** @returns SomeType */`
+- Commit messages: feat(scope), fix(scope), docs(scope), test(scope)

--- a/_agents/orchestrator.md
+++ b/_agents/orchestrator.md
@@ -1,0 +1,38 @@
+# Orchestrator
+
+## Purpose
+
+Coordinates overall project strategy, breaks work into tasks, delegates to specialists, and manages dependencies across the codebase.
+
+## Responsibilities
+
+- Understand the full Voiler architecture (frontend, API, auth, database)
+- Translate requirements into concrete tasks with clear scope
+- Assign work to Architect, Developer, Reviewer, QA Designer, Tester
+- Track dependencies and critical path
+- Verify tasks are complete before marking done
+- Run verification (`pnpm lint`, `pnpm typecheck`, `pnpm test`) after each completed task
+
+## Key Knowledge
+
+- Hexagonal architecture: domain → use cases → ports → adapters
+- Monorepo structure: packages, workspace setup, shared configs
+- Critical decisions documented in `/docs/superpowers/specs/`
+- Plan contracts and dependencies in `/docs/superpowers/plans/`
+- Git workflow: branches, PRs, commit conventions
+
+## Tools & Commands
+
+- `git status`, `git log`, `git diff` — understand current state
+- `pnpm list -r` — inspect monorepo dependencies
+- `pnpm lint`, `pnpm typecheck`, `pnpm test` — verify quality
+- `turbo run dev` — understand task graph
+- `gh pr view`, `gh issue list` — track work items
+
+## Guidelines
+
+- Break work into tasks <4 hours each
+- Establish blockers/dependencies explicitly
+- Always verify before signing off on "complete"
+- Use double-agent review pattern for critical PRs
+- Document decisions in ADRs if they affect multiple packages

--- a/_agents/qa-designer.md
+++ b/_agents/qa-designer.md
@@ -1,0 +1,44 @@
+# QA Designer
+
+## Purpose
+
+Designs test strategies, coverage plans, and TDD workflows. Knows Vitest for unit testing and Playwright for E2E testing.
+
+## Responsibilities
+
+- Plan test coverage: what to unit test (domain logic), what to E2E test (user flows)
+- Design test data and fixtures
+- Establish TDD workflow: write tests first, implement to pass
+- Review test quality: do they test behavior, not implementation?
+- Guide Tester on test structure and assertions
+- Identify gaps: untested error paths, edge cases, security scenarios
+- Plan E2E scenarios: critical user journeys, auth flows, data validation
+
+## Key Knowledge
+
+- **Vitest unit tests** — domain logic, use cases, utilities
+  - Location: `packages/*/src/**/*.test.ts`
+  - Fixtures in `packages/*/src/__fixtures__/`
+  - Run: `pnpm test`
+- **Playwright E2E** — full user flows, API integration
+  - Location: `apps/*/e2e/**/*.spec.ts`
+  - Run: `pnpm test:e2e` (requires dev server)
+- **TDD cycle:** write test → watch fail → implement → watch pass → refactor
+- **Test data:** use factories/fixtures, avoid hardcoded values
+- **Error scenarios:** test Result.err() paths, validation failures, auth failures
+
+## Tools & Commands
+
+- `pnpm test` — run all Vitest unit tests
+- `pnpm test:e2e` — run Playwright (requires `pnpm --filter @voiler/api dev`)
+- `pnpm test -- --coverage` — coverage report
+- `vitest watch` — TDD mode (watch file changes)
+
+## Guidelines
+
+- Unit tests = domain logic, algorithms, pure functions
+- E2E tests = user journeys, critical paths (auth, payment if present)
+- Every Result.err() case needs a test
+- Test behavior, not implementation: assert outcomes, not call counts
+- Before implementing: "What would a failing test look like?"
+- 80/20 rule: high-value coverage first (happy path + critical errors)

--- a/_agents/reviewer.md
+++ b/_agents/reviewer.md
@@ -1,0 +1,42 @@
+# Reviewer
+
+## Purpose
+
+Reviews code for security, correctness, and style compliance. Uses double-agent review pattern: strict reviewer + pragmatic triager.
+
+## Responsibilities
+
+- Check coding mandates: no semicolons, typedef, max-1-param, trailing commas, max-100-chars
+- Verify no `throw`/`try-catch` in business logic
+- Ensure Result/ResultAsync exhaustion (`.match()` or `switch`)
+- Check hexagonal violations: domain imports infrastructure
+- Review tRPC routers are thin (parse → use case → return)
+- Validate Zod schema usage and type inference
+- Run linting, typechecking, tests on proposed code
+- Use double-agent: strict reviewer flags issues, triager prioritizes by impact
+
+## Key Knowledge
+
+- ESLint rules: no-semicolons, typedef, curly braces, trailing commas
+- Forbidden patterns: `throw`, `try-catch`, `any`, casts (`as unknown`, `as any`)
+- Result pattern: `.ok()`, `.err()`, `.match({ ok, err })`, `.mapErr()`, `.andThen()`
+- Hexagonal: domain ⊄ infrastructure; only use cases → adapters
+- tRPC: input (parse) → use case → result (return)
+- Type safety: explicit on all `const`, no implicit `any`
+
+## Tools & Commands
+
+- `pnpm lint` — catch style/rule violations
+- `pnpm typecheck` — catch type errors
+- `pnpm test` — verify tests pass (or write before code)
+- `grep -r "throw " --include="*.ts" src/domain` — audit domain purity
+- `grep -r "as any\|as unknown" --include="*.ts"` — find casts
+
+## Guidelines
+
+- **Strict reviewer first:** Flag every mandate violation, no mercy
+- **Triager second:** Separate critical (security, type safety) from polish (whitespace)
+- **Evidence required:** Show the line, explain the rule, cite CLAUDE.md
+- **Constructive:** Suggest fixes, don't just complain
+- **Test-first:** If logic changed, tests must exist and pass
+- **Double-check verification:** Run all four checks (lint, typecheck, test, format)

--- a/_agents/tester.md
+++ b/_agents/tester.md
@@ -1,0 +1,53 @@
+# Tester
+
+## Purpose
+
+Writes and runs tests following TDD. Knows test structure, assertions, and how to validate both happy paths and error cases.
+
+## Responsibilities
+
+- Write unit tests in Vitest: domain logic, use cases, adapters
+- Write E2E tests in Playwright: user journeys, API contracts
+- Follow TDD: test first, code to pass
+- Test all Result paths: both `.ok()` and `.err()` cases
+- Use appropriate assertions: equality, deep equality, error messages
+- Keep tests focused: one behavior per test
+- Maintain fixtures and test data
+- Run tests frequently during development
+
+## Key Knowledge
+
+- **Vitest syntax:**
+  - `describe()`, `it()` — organize tests
+  - `expect()` — assertions (toEqual, toThrow, toMatch, toBeTruthy, etc.)
+  - `.toEqual()` — deep equality
+  - `vi.mock()` — mock modules
+  - `beforeEach()`, `afterEach()` — setup/teardown
+- **Playwright syntax:**
+  - `test()`, `expect()` — define and assert
+  - `page.goto()`, `page.click()`, `page.fill()` — interact
+  - `expect(page).toHaveURL()`, `toContainText()` — UI assertions
+  - `await page.request.post()` — API testing
+- **Result pattern:** `.match({ ok: (v) => ..., err: (e) => ... })`
+- **Test file locations:**
+  - Unit: `packages/*/src/**/*.test.ts`
+  - E2E: `apps/*/e2e/**/*.spec.ts`
+  - Fixtures: `packages/*/src/__fixtures__/**`
+
+## Tools & Commands
+
+- `pnpm test` — run all Vitest tests
+- `pnpm test -- --watch` — watch mode (TDD)
+- `pnpm test:e2e` — run Playwright (requires dev server running)
+- `pnpm test -- path/to/test.ts` — run single test file
+- `pnpm test -- -t "test name"` — run by pattern
+
+## Guidelines
+
+- **TDD first:** Write failing test before implementing
+- **One behavior per test:** If test name has "and", split it
+- **Test names clear:** `it("returns err when email invalid")` not `it("validates")`
+- **Result testing:** Always test both `.ok()` and `.err()` branches
+- **Fixtures over hardcodes:** Use factories for test data
+- **Assertions specific:** Check exact values, not just truthy
+- **E2E last:** Prefer unit tests, use E2E only for critical flows

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -1,0 +1,31 @@
+# @voiler/api
+
+Hono HTTP server with tRPC router, Better Auth, and hexagonal DI container.
+
+## Key Files
+
+| File                   | Purpose                                                      |
+| ---------------------- | ------------------------------------------------------------ |
+| `src/index.ts`         | Server entrypoint, middleware stack, route wiring            |
+| `src/container.ts`     | DI container -- only file importing concrete adapters        |
+| `src/auth/index.ts`    | Better Auth factory (sessions, OAuth, admin plugin)          |
+| `src/trpc/context.ts`  | tRPC context, procedure guards (public/authed/admin/dev)     |
+| `src/trpc/router.ts`   | Root tRPC router composing sub-routers                       |
+| `src/trpc/procedures/` | Sub-routers: user, session, admin, email, payments           |
+| `src/use-cases/`       | Business logic factories (receive ports, return ResultAsync) |
+| `src/adapters/`        | Concrete implementations of core ports (Drizzle)             |
+| `src/logging/`         | Request logger, audit log, use-case logger, cleanup          |
+| `src/middleware/`      | Security headers, CSRF, rate limiter                         |
+| `src/http/health.ts`   | GET /health endpoint                                         |
+
+## Commands
+
+```bash
+pnpm --filter @voiler/api dev       # Dev server (port 4000)
+pnpm --filter @voiler/api db:push   # Push schema to DB
+pnpm --filter @voiler/api test      # Unit tests
+```
+
+## Architecture
+
+See [../../docs/architecture.md] and [../../docs/auth.md].

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,27 @@
+# @voiler/web
+
+TanStack Start frontend (SSR + SPA hybrid) with tRPC client, Better Auth client, and Paraglide i18n.
+
+## Key Files
+
+| File                   | Purpose                                                   |
+| ---------------------- | --------------------------------------------------------- |
+| `src/router.tsx`       | TanStack router setup                                     |
+| `src/routes/`          | File-based routes (auth, dashboard, admin, settings)      |
+| `src/components/`      | Shared components (NavBar, RoleGate, ImpersonationBanner) |
+| `src/lib/trpc.ts`      | tRPC client configuration                                 |
+| `src/lib/auth.ts`      | Better Auth client                                        |
+| `src/lib/i18n.tsx`     | Paraglide i18n setup                                      |
+| `e2e/`                 | Playwright E2E tests                                      |
+| `playwright.config.ts` | Playwright configuration                                  |
+
+## Commands
+
+```bash
+pnpm --filter @voiler/web dev    # Dev server (port 3000)
+pnpm test:e2e                    # Playwright E2E (needs API running)
+```
+
+## Architecture
+
+See [../../docs/architecture.md] and [../../docs/auth.md].

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,115 @@
+# Architecture
+
+Voiler follows **hexagonal architecture** (ports and adapters). The domain layer is pure logic with zero infrastructure imports. Use cases depend only on port interfaces. Concrete adapters are wired in a single DI container file.
+
+## Package Structure
+
+```
+voiler/
+  apps/
+    api/          -- Hono server, tRPC router, adapters, DI container
+    web/          -- TanStack Start frontend (SSR + SPA)
+  packages/
+    domain/       -- Entities, value objects, domain errors (zero deps)
+    core/         -- Port interfaces, AppError union (depends on domain)
+    schema/       -- Drizzle tables + Zod schemas (single source of truth)
+    config-env/   -- Zod-validated env config with fail-fast
+    config-ts/    -- Shared tsconfig bases
+    ui/           -- Shared UI components (Tailwind + shadcn/ui)
+```
+
+## Layer Dependency Rules
+
+```
+domain  <--  core  <--  apps/api
+  (zero deps)  (ports only)  (adapters + wiring)
+```
+
+| Rule                     | Description                                                      |
+| ------------------------ | ---------------------------------------------------------------- |
+| Domain imports nothing   | Only TS stdlib, neverthrow for Result types                      |
+| Core imports domain only | Defines port interfaces (e.g., `IUserRepository`)                |
+| API imports everything   | Wires adapters to ports in `container.ts`                        |
+| Schema is shared         | Used by both API (Drizzle queries) and frontend (Zod validation) |
+
+## Data Flow
+
+```
+HTTP Request
+  |
+  v
+Hono Middleware (rate limit, logging, security, CORS, CSRF, body limit)
+  |
+  v
+Better Auth (/api/auth/**)  OR  tRPC Router (/trpc/*)
+  |                                |
+  v                                v
+Session extraction           tRPC Procedure (input validation via Zod)
+  |                                |
+  v                                v
+Context (db, requestId,      Use Case (pure logic, returns ResultAsync)
+  user, session)                   |
+                                   v
+                             Repository Port (IUserRepository)
+                                   |
+                                   v
+                             Drizzle Adapter (concrete DB implementation)
+                                   |
+                                   v
+                             PostgreSQL
+```
+
+## Dependency Injection
+
+`apps/api/src/container.ts` is the **only file** that imports concrete adapters:
+
+```typescript
+const createContainer: (params: CreateContainerParams) => Container = (params) => {
+  const { db } = params
+
+  // Concrete adapter -- only imported here
+  const userRepository = createDrizzleUserRepository({ db })
+
+  // Use cases receive ports, not implementations
+  const rawCreateUser = createCreateUser({ userRepository })
+
+  // Wrap with cross-cutting concerns (audit logging)
+  const createUser = withAuditLog({
+    name: 'user.create',
+    useCase: rawCreateUser,
+    getEntityId: (result) => String(result.id),
+    db,
+  })
+
+  return { createUser /* ... */ }
+}
+```
+
+## tRPC Routers Are Thin
+
+Routers only: parse input, call use case, map result. No business logic:
+
+```typescript
+create: adminProcedure.input(CreateUserInputSchema).mutation(async (opts) => {
+  const result = await createUser({
+    name: opts.input.name,
+    email: opts.input.email,
+  })
+
+  return result.match(
+    (entity) => mapToPublicUser({ entity }),
+    (error) => throwTrpcError({ error }),
+  )
+})
+```
+
+## Module Markers
+
+Future modules use comment markers for activation:
+
+```typescript
+// [MODULE:payments] import { createStubPaymentService } from '@voiler/mod-payments'
+// [MODULE:email] import { createStubEmailService } from '@voiler/mod-email'
+```
+
+Uncomment when the module is implemented. This keeps the container forward-compatible.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,165 @@
+# Authentication
+
+Voiler uses **Better Auth** with the Drizzle adapter for PostgreSQL. Authentication supports email/password and optional OAuth (Google, GitHub).
+
+## Setup
+
+The auth instance is created in `apps/api/src/auth/index.ts`:
+
+```typescript
+const auth = betterAuth({
+  database: drizzleAdapter(db, { provider: 'pg' }),
+  secret,
+  trustedOrigins,
+  session: {
+    cookieCache: { enabled: true, maxAge: 300 },
+  },
+  advanced: {
+    cookiePrefix: 'voiler',
+    defaultCookieAttributes: {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'lax',
+      path: '/',
+    },
+  },
+  emailAndPassword: { enabled: true },
+  socialProviders: {
+    // Conditionally included based on env vars
+    ...(googleClientId && googleClientSecret
+      ? {
+          google: {
+            /* ... */
+          },
+        }
+      : {}),
+    ...(githubClientId && githubClientSecret
+      ? {
+          github: {
+            /* ... */
+          },
+        }
+      : {}),
+  },
+  user: {
+    additionalFields: {
+      role: { type: 'string', defaultValue: 'user', input: false },
+    },
+  },
+  plugins: [admin()],
+})
+```
+
+## Auth Routes
+
+Better Auth handles all auth endpoints at `/api/auth/**`:
+
+```typescript
+app.on(['POST', 'GET'], '/api/auth/**', (c) => {
+  return auth.handler(c.req.raw)
+})
+```
+
+## Session Extraction
+
+A Hono middleware extracts the session for every non-auth request:
+
+```typescript
+app.use('*', async (c, next) => {
+  if (c.req.path.startsWith('/api/auth/')) {
+    c.set('user', null)
+    c.set('session', null)
+    await next()
+    return
+  }
+
+  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+  c.set('user', session?.user ?? null)
+  c.set('session', session?.session ?? null)
+  await next()
+})
+```
+
+## tRPC Context Enrichment
+
+The session is injected into every tRPC context:
+
+```typescript
+interface TRPCContext {
+  readonly db: DbClient
+  readonly requestId: string
+  readonly user: AuthUser | null
+  readonly session: AuthSession | null
+  readonly headers: Headers
+}
+```
+
+## Procedure Guards
+
+| Procedure         | Requirement                   | Use                       |
+| ----------------- | ----------------------------- | ------------------------- |
+| `publicProcedure` | None                          | Public queries            |
+| `authedProcedure` | Valid session                 | User-facing endpoints     |
+| `adminProcedure`  | `role === 'admin'`            | Admin CRUD, impersonation |
+| `devProcedure`    | `role === 'dev'` or `'admin'` | Developer tools           |
+
+Guards narrow the context type to `AuthedTRPCContext` (guaranteed non-null user/session).
+
+## Cookie Configuration
+
+| Setting  | Value          | Notes                        |
+| -------- | -------------- | ---------------------------- |
+| Prefix   | `voiler`       | Namespaced cookies           |
+| httpOnly | `true`         | No JS access                 |
+| secure   | `true` in prod | HTTPS only in production     |
+| sameSite | `lax`          | Allows top-level navigations |
+| path     | `/`            | Available site-wide          |
+| Cache    | 300s           | Session cookie cache TTL     |
+
+## Impersonation
+
+Admin users can impersonate other users via the admin plugin:
+
+```typescript
+impersonate: adminProcedure.input(ImpersonateInputSchema).mutation(async (opts) => {
+  // Self-impersonation blocked
+  if (opts.ctx.user.id === opts.input.userId) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot impersonate yourself' })
+  }
+
+  await impersonateUser({ headers: opts.ctx.headers, userId: opts.input.userId })
+
+  // Audit logged for security
+  await writeAuditLogAsync({
+    db: opts.ctx.db,
+    entry: {
+      requestId: opts.ctx.requestId,
+      action: 'admin.impersonate',
+      userId: opts.ctx.user.id,
+      entityId: opts.input.userId,
+      metadata: { impersonatedBy: opts.ctx.user.id },
+    },
+  })
+
+  return { success: true }
+})
+```
+
+## OAuth Configuration
+
+Set these env vars to enable social login:
+
+| Variable                                    | Provider     |
+| ------------------------------------------- | ------------ |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | GitHub OAuth |
+
+Providers are only enabled when both client ID and secret are present.
+
+## Rate Limiting
+
+Auth endpoints have stricter rate limits (10 req/min per IP vs. default):
+
+```typescript
+app.use('/api/auth/*', createRateLimiter({ windowMs: 60_000, max: 10, keyPrefix: 'auth' }))
+```

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,0 +1,153 @@
+# Code Standards
+
+All coding mandates for the Voiler project. Enforced by ESLint, Prettier, and tsc.
+
+## Communication
+
+- **Chat language:** Spanish only. Internal thinking: English allowed.
+- **Code language:** All code, comments, logs, and docs in English.
+- **Critical agency:** Treat every request as a refutable hypothesis.
+
+## No Semicolons
+
+Prettier is configured with `semi: false`. Never add semicolons.
+Prettier auto-removes them, so this is enforced automatically.
+If you see a semicolon in a diff, your editor is misconfigured.
+
+## Arrow Functions Only
+
+Use arrow functions for all logic and components. No `function` declarations:
+
+```typescript
+// GOOD
+const createEmail: (params: CreateEmailParams) => Result<Email, DomainError> = (params) => {
+  const { value } = params
+  // ...
+}
+
+// BAD
+function createEmail(params: CreateEmailParams): Result<Email, DomainError> {
+  // ...
+}
+```
+
+## Max 1 Parameter -- Object Params
+
+Arrow functions take at most 1 parameter. Multiple values are wrapped in an object:
+
+```typescript
+// GOOD
+interface CreateUserParams {
+  readonly name: string
+  readonly email: string
+}
+
+const createUser: (params: CreateUserParams) => ResultAsync<UserEntity, AppError> = (params) => {
+  const { name, email } = params
+  // ...
+}
+
+// BAD
+const createUser = (name: string, email: string) => {
+  /* ... */
+}
+```
+
+## Trust TS Inference
+
+Do **not** annotate types when TypeScript infers correctly. **Do** annotate when initializing objects destined as function arguments (pre-validation pattern -- so errors point to the wrong property, not the call site):
+
+```typescript
+// GOOD -- inferred
+const trimmed = value.trim().toLowerCase()
+
+// GOOD -- pre-validation: annotate to catch errors at declaration
+const startLog: RequestStartLog = {
+  level: 'info',
+  event: 'request.start',
+  requestId,
+  method,
+  path,
+  timestamp: new Date(startMs).toISOString(),
+}
+
+// BAD -- redundant annotation
+const trimmed: string = value.trim().toLowerCase()
+```
+
+**Explicit return types** are required on all exported functions.
+
+## `const` Over `let`, No Mutation
+
+Always use `const`. Never reassign. Never mutate objects or arrays:
+
+```typescript
+// GOOD
+const ageDays: number = maxAgeDays ?? DEFAULT_MAX_AGE_DAYS
+const cutoffMs: number = Date.now() - ageDays * MS_PER_DAY
+const cutoffDate: Date = new Date(cutoffMs)
+
+// BAD
+let cutoffDate = new Date()
+cutoffDate.setDate(cutoffDate.getDate() - 30)
+```
+
+## Trailing Commas
+
+Always use trailing commas in multi-line structures:
+
+```typescript
+// GOOD
+return {
+  createUser,
+  getUser,
+  listUsers,
+}
+```
+
+## Line Length
+
+Prettier handles formatting at `printWidth: 100`. No hard ESLint limit.
+
+## TypeScript Strictness
+
+- `any` is **forbidden**. Use proper types or generics.
+- Casting (`as any`, `as unknown`) is **forbidden**. The only exception is branded types (e.g., `as Email`).
+- Parameter types defined as separate interfaces, destructured in the function body:
+
+```typescript
+interface WriteAuditLogParams {
+  readonly db: DbClient
+  readonly entry: AuditLogEntry
+}
+
+const writeAuditLog: (params: WriteAuditLogParams) => void = (params) => {
+  const { db, entry } = params
+  // ...
+}
+```
+
+## JSDoc
+
+All exported functions must have JSDoc:
+
+```typescript
+/**
+ * Validate and create an Email value object.
+ *
+ * @returns A Result containing the branded Email or a DomainError.
+ */
+export const createEmail: (params: CreateEmailParams) => Result<Email, DomainError> = (params) => {
+  // ...
+}
+```
+
+## `readonly` on Interface Properties
+
+All interface properties use `readonly`:
+
+```typescript
+interface CreateContainerParams {
+  readonly db: DbClient
+}
+```

--- a/docs/decisions/001-hexagonal-architecture.md
+++ b/docs/decisions/001-hexagonal-architecture.md
@@ -1,0 +1,67 @@
+# ADR-001: Hexagonal Architecture
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+Voiler is an AI-first boilerplate intended to serve as a foundation for multiple web
+applications. The architecture needs to support swapping infrastructure dependencies
+(database, auth, email, cache) without touching business logic. It also needs to be
+testable in isolation, without spinning up a database or HTTP server.
+
+The primary concern is preventing business logic from being entangled with infrastructure.
+In most Express/Next.js codebases, database calls, HTTP logic, and domain rules end up
+in the same function. This makes testing hard, migration expensive, and AI agents likely
+to introduce hidden coupling when generating code.
+
+## Decision
+
+We adopt Hexagonal Architecture (Ports and Adapters) as the structural pattern.
+
+- `packages/domain` contains entities, value objects, and port interfaces. Zero imports
+  from infrastructure packages.
+- `packages/core` contains use cases that depend only on port interfaces.
+- Concrete adapters (Drizzle repositories, Hono routes, Better Auth) live in
+  `apps/api/src/adapters/`.
+- `apps/api/src/container.ts` is the only file that wires concrete adapters to port
+  interfaces. This is the composition root.
+- tRPC routers are thin: they parse input, call a use case, and return the result.
+
+This enforces a strict dependency rule: inner layers never import outer layers.
+
+## Alternatives Considered
+
+**Layered Architecture (Controller → Service → Repository)**
+The traditional three-layer model is simpler to understand but does not enforce
+infrastructure isolation. Services commonly import ORM models directly, making
+unit testing require mocking heavy dependencies.
+
+**Clean Architecture (Uncle Bob)**
+Clean Architecture and Hexagonal are closely related. Clean Architecture adds
+explicit "Use Case Interactor" and "Presenter" concepts that introduce boilerplate
+without tangible benefit for a JSON API. Hexagonal achieves the same isolation
+with fewer layers.
+
+**No explicit architecture**
+Feature-folder organization with no enforced boundaries. Fast to start but
+degrades rapidly as the codebase grows. Not suitable for a boilerplate intended
+to stay maintainable across plans.
+
+## Consequences
+
+**Positive:**
+
+- Domain and use case logic can be unit-tested without a database.
+- Infrastructure can be swapped (e.g., Drizzle → Prisma, PostgreSQL → SQLite for
+  tests) by changing only the adapter and the composition root.
+- AI agents have clear rules about where new code belongs, reducing accidental
+  coupling.
+- Port interfaces serve as documentation of what each use case requires.
+
+**Negative:**
+
+- More files and indirection than a simple layered approach.
+- New contributors (or agents) must understand the port/adapter pattern before
+  contributing correctly.
+- Boilerplate for simple CRUD operations can feel excessive.

--- a/docs/decisions/002-neverthrow-over-trycatch.md
+++ b/docs/decisions/002-neverthrow-over-trycatch.md
@@ -1,0 +1,72 @@
+# ADR-002: neverthrow Over try/catch
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+Error handling in TypeScript is invisible by default. A function that throws is
+indistinguishable from one that does not at the call site. This means callers have
+no compile-time signal that an error path exists, and errors routinely propagate
+unhandled until they reach a generic top-level handler.
+
+For a boilerplate that emphasizes correctness and AI-agent-driven development, we need
+error handling that is:
+
+1. Explicit in the type signature — callers must acknowledge error cases.
+2. Exhaustive — the compiler should flag unhandled branches.
+3. Composable — multiple fallible operations should chain without nested try/catch.
+4. Readable — business logic should not be buried in exception scaffolding.
+
+## Decision
+
+All fallible functions return `Result<T, E>` or `ResultAsync<T, E>` from
+[neverthrow](https://github.com/supermacro/neverthrow).
+
+- `throw` and `try/catch` are forbidden for business logic.
+- Errors are modeled as discriminated union types with a `tag` field.
+- Results are handled exhaustively using `.match()` or a `switch` on `tag`.
+- Use cases that call multiple fallible operations use `.andThen()` and `.mapErr()`
+  to compose without nesting.
+
+tRPC routers receive a `Result` from a use case and map it to an appropriate HTTP
+response or tRPC error. Error mapping happens at the boundary, not inside business
+logic.
+
+## Alternatives Considered
+
+**try/catch with custom error classes**
+Familiar pattern but errors are invisible in type signatures. TypeScript's `unknown`
+catch type requires manual narrowing. Composing multiple fallible calls produces
+deeply nested or early-return code that is easy to get wrong.
+
+**Effect-TS**
+Effect provides a more powerful functional runtime (fibers, dependency injection,
+tracing). However, it introduces a steep learning curve, a large runtime, and
+requires adopting a distinct programming model throughout the codebase. For a
+boilerplate with a single-developer team, the complexity-to-benefit ratio is
+unfavorable at this stage.
+
+**ts-results**
+Similar to neverthrow. neverthrow has better async ergonomics (`ResultAsync`),
+broader adoption, and more active maintenance.
+
+**Returning `{ data, error }` tuples**
+Simple but not type-narrowing. TypeScript cannot infer that `data` is defined when
+`error` is null without explicit discriminated union support.
+
+## Consequences
+
+**Positive:**
+
+- Error paths are visible in function signatures — no hidden control flow.
+- The compiler enforces exhaustive handling when using discriminated unions.
+- Business logic reads as a pipeline of transformations, not nested try/catch.
+- AI agents generating code are forced to model errors explicitly.
+
+**Negative:**
+
+- Developers unfamiliar with Result types face an initial learning curve.
+- Third-party libraries throw; adapter code must wrap those calls in `fromThrowable`
+  or `ResultAsync.fromPromise`, adding a thin conversion layer at every boundary.
+- Stack traces are less automatic; errors must carry context explicitly.

--- a/docs/decisions/003-zod-single-source-of-truth.md
+++ b/docs/decisions/003-zod-single-source-of-truth.md
@@ -1,0 +1,80 @@
+# ADR-003: Zod as Single Source of Truth for Validation and Types
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+A fullstack application needs validation in multiple places: database schema, API
+input parsing, form validation, and internal domain invariants. Without a shared
+source of truth, these definitions drift. A field added to the database requires
+matching updates to DTOs, form schemas, and TypeScript interfaces — each a separate
+file, each a potential mismatch.
+
+We need a validation library that:
+
+1. Produces TypeScript types automatically, so there is one definition per entity.
+2. Runs at runtime for input parsing (tRPC, form data, environment variables).
+3. Integrates with the ORM so database schema and validation stay in sync.
+4. Is composable — partial schemas, transforms, and refinements should be first-class.
+
+## Decision
+
+[Zod](https://zod.dev) is the single source of truth for all validation and type
+definitions in Voiler.
+
+- `packages/schema` contains Zod schemas for all entities. TypeScript types are
+  derived with `z.infer<>`, never written by hand.
+- `drizzle-zod` generates Zod insert/select schemas directly from Drizzle table
+  definitions, keeping ORM schema and validation in sync.
+- tRPC input validators are Zod schemas from `packages/schema`.
+- Environment variable validation (`packages/env`) uses Zod to fail fast on startup.
+- Domain value objects use Zod `.brand()` for nominal typing without runtime overhead.
+
+The ESLint rule `@typescript-eslint/typedef` is disabled per-line for Zod `const`
+declarations, since the type is inferred from the schema.
+
+## Alternatives Considered
+
+**io-ts**
+Functional codec library with strong theoretical foundations. However, it requires
+`fp-ts` as a peer, produces verbose error messages by default, and has a steeper
+learning curve. Zod's error messages are more developer-friendly and its API is
+more ergonomic for typical web application schemas.
+
+**Yup**
+Popular in form libraries. Lacks native TypeScript-first design; types are inferred
+less precisely. Does not integrate with Drizzle. Async validation is less composable.
+
+**Valibot**
+Newer, tree-shakable, smaller bundle. Less mature ecosystem and fewer integrations
+(notably no official drizzle-valibot at the time of decision). Worth revisiting.
+
+**Separate TypeScript interfaces + manual validation**
+Defining types in `.d.ts` files and writing validation logic separately. This is
+the source of drift the decision is designed to eliminate. Any change to a type
+requires finding and updating all validators manually.
+
+**Arktype**
+Strong static type inference without codegen. Less ecosystem support and fewer
+Drizzle integrations than Zod at the time of decision.
+
+## Consequences
+
+**Positive:**
+
+- One schema definition produces the TypeScript type, the runtime validator, and
+  the database insert/select types via `drizzle-zod`.
+- Refactoring an entity requires editing one schema; downstream types update
+  automatically via `z.infer<>`.
+- tRPC input validation and form validation reuse the same schema objects.
+- AI agents have a single location to look up or modify type definitions.
+
+**Negative:**
+
+- `drizzle-zod` version pinning is required; minor versions have broken inference.
+  (Pinned to a known-good version in `packages/schema/package.json`.)
+- Very complex schemas (recursive types, highly conditional transforms) can produce
+  inscrutable TypeScript errors.
+- Bundle size: Zod is ~14 KB minified+gzipped. Acceptable for server-side use;
+  requires tree-shaking discipline for client bundles.

--- a/docs/decisions/004-trpc-over-graphql.md
+++ b/docs/decisions/004-trpc-over-graphql.md
@@ -1,0 +1,81 @@
+# ADR-004: tRPC Over GraphQL
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+The API layer needs to expose typed procedures to a TypeScript frontend. The primary
+requirements are:
+
+1. End-to-end type safety — a change to a procedure signature should surface as a
+   TypeScript error in the client without manual type regeneration.
+2. Low boilerplate — defining a new endpoint should not require touching a schema
+   file, a resolver file, and a client type file separately.
+3. Composable middleware — auth, rate limiting, and logging should apply to procedure
+   groups without repeating code.
+4. Compatible with the Hono HTTP server — the API runs on Hono; the RPC layer should
+   integrate cleanly.
+
+## Decision
+
+We use [tRPC v11](https://trpc.io) as the RPC framework, mounted on a Hono router via
+`@hono/trpc-server`.
+
+- Procedures are defined in `apps/api/src/routers/`.
+- Input is validated with Zod schemas from `packages/schema`.
+- Context is built once per request in `apps/api/src/trpc/context.ts` and carries
+  the authenticated session and injected use-case dependencies.
+- Routers are thin: they parse input, call a use case, and return the result.
+  No business logic lives in a router.
+- The client (`packages/client`) exports a typed tRPC client using `createTRPCClient`.
+
+## Alternatives Considered
+
+**GraphQL (Apollo Server / Pothos)**
+GraphQL provides a self-documenting schema, powerful query flexibility, and a rich
+ecosystem. However, for a TypeScript-only client/server pair:
+
+- The schema is a third artifact (SDL) that must stay in sync with resolvers and
+  TypeScript types. tRPC eliminates this duplication.
+- Type generation requires a codegen step (`graphql-codegen`). tRPC types flow
+  directly through the TypeScript compiler.
+- GraphQL query flexibility (field selection, nested queries) is valuable for
+  public APIs or multiple consumers. Voiler has one TypeScript consumer.
+- Resolver boilerplate is higher than tRPC procedure definitions.
+
+GraphQL remains the right choice if the API needs to serve mobile apps, third-party
+consumers, or a schema-first contract. That is not the current use case.
+
+**REST with OpenAPI**
+REST is universally understood and tooling is mature. But generating a typed client
+from an OpenAPI spec requires a codegen step, and keeping the spec in sync with
+implementation requires discipline or additional tooling (e.g., Zod-to-OpenAPI).
+tRPC gives the same type safety with less configuration.
+
+**Hono RPC (built-in)**
+Hono has a built-in typed RPC layer. It is lighter weight than tRPC but has a smaller
+ecosystem, fewer middleware primitives, and no subscription support. tRPC's middleware
+composition model is more expressive for auth and multi-tenant scenarios.
+
+## Consequences
+
+**Positive:**
+
+- A TypeScript error at the API definition immediately surfaces in the client.
+  No codegen, no drift.
+- Adding a new procedure requires one file edit; the client type updates
+  automatically.
+- Input validation is handled by Zod at the procedure boundary — no duplicate
+  parsing logic.
+- tRPC middleware composes cleanly with Hono middleware at the HTTP level.
+
+**Negative:**
+
+- tRPC is not consumable by non-TypeScript clients without an OpenAPI adapter
+  (e.g., `trpc-openapi`). If a public REST API is needed later, an adapter layer
+  must be added.
+- Debugging tRPC errors requires understanding the tRPC error shape; HTTP status
+  codes are less granular by default.
+- Subscriptions require WebSocket or SSE setup; not needed now but adds complexity
+  if introduced later.

--- a/docs/decisions/005-better-auth-over-authjs.md
+++ b/docs/decisions/005-better-auth-over-authjs.md
@@ -1,0 +1,84 @@
+# ADR-005: Better Auth Over Auth.js
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+The application requires authentication with the following capabilities:
+
+1. Email/password and OAuth (GitHub, Google at minimum).
+2. Database-persisted sessions — not JWTs stored in cookies, which require rotation
+   and revocation infrastructure.
+3. An impersonation mechanism for admin workflows.
+4. Drizzle ORM integration — session and user tables should live in the application
+   database and be queryable with the existing ORM.
+5. TypeScript-native API — the auth library should not require manual type augmentation.
+
+The auth layer must integrate with Hono (the HTTP server) and expose typed helpers
+usable in tRPC context.
+
+## Decision
+
+We use [Better Auth](https://better-auth.com) as the authentication library.
+
+- Better Auth is configured in `apps/api/src/lib/auth.ts` with the Drizzle adapter.
+- Session tables are generated and managed by Better Auth's schema utilities, then
+  merged with the application Drizzle schema.
+- The `impersonation` plugin is enabled, allowing admin users to act as other users.
+- OAuth providers (GitHub, Google) are configured via environment variables.
+- Better Auth's Hono integration mounts auth routes at `/api/auth/*`.
+- The tRPC context reads the session from Better Auth on each request.
+
+## Alternatives Considered
+
+**Auth.js (NextAuth v5)**
+Auth.js is the most widely adopted auth library for Node.js. However:
+
+- It was designed for Next.js and has first-class support for Next.js App Router.
+  Integrating with Hono requires community adapters with uncertain maintenance.
+- Its database adapter for Drizzle exists but requires schema conventions that
+  conflict with the application schema design.
+- Session handling defaults to JWT; database sessions require explicit configuration
+  and are less ergonomic.
+- Impersonation is not a built-in feature; implementing it requires patching the
+  session callback.
+
+**Lucia**
+Lucia v3 is a minimal, framework-agnostic session library. It provides session
+management primitives but not a full auth solution. OAuth flows, email verification,
+and password hashing must be implemented manually or via separate packages. This is
+appropriate for teams wanting full control but adds significant implementation scope
+for a boilerplate.
+
+**Custom implementation**
+Building auth from primitives (`oslo`, `arctic` for OAuth, `argon2` for hashing)
+gives maximum control. The risk is implementing security-sensitive code incorrectly.
+Better Auth handles the security-critical paths (password hashing, session token
+generation, CSRF protection) with a maintained library.
+
+**Clerk / Auth0 (managed services)**
+Excellent developer experience but introduce a third-party dependency for a
+security-critical path. Not suitable for self-hosted deployments. Also add per-MAU
+cost.
+
+## Consequences
+
+**Positive:**
+
+- Database sessions are first-class; revocation is a single row delete.
+- Impersonation is a built-in plugin — no custom session manipulation required.
+- Drizzle adapter keeps auth tables in the application database, queryable with
+  the same ORM as the rest of the application.
+- OAuth providers are configured declaratively; adding a new provider is a
+  one-line change.
+- TypeScript types for sessions and users are generated from the schema, not
+  written manually.
+
+**Negative:**
+
+- Better Auth is newer and less battle-tested than Auth.js. Community resources and
+  Stack Overflow coverage are thinner.
+- Schema migrations for auth tables are managed separately from application
+  migrations; a merge step is required when updating Better Auth versions.
+- Fewer community plugins than Auth.js at the time of decision.

--- a/docs/decisions/006-hono-over-express.md
+++ b/docs/decisions/006-hono-over-express.md
@@ -1,0 +1,84 @@
+# ADR-006: Hono Over Express
+
+**Status:** Accepted
+**Date:** 2026-04-03
+
+## Context
+
+The API needs an HTTP server that:
+
+1. Handles routing, middleware, and request/response with good TypeScript support.
+2. Can run on Node.js today and potentially on edge runtimes (Cloudflare Workers,
+   Bun, Deno) in the future without a full rewrite.
+3. Has a composable middleware system compatible with security requirements (CSP,
+   CORS, rate limiting, secure headers).
+4. Integrates with tRPC and Better Auth without heavy adapter layers.
+5. Is lightweight — the API is the only backend; there is no need for a full
+   application framework.
+
+## Decision
+
+We use [Hono](https://hono.dev) as the HTTP framework.
+
+- The Hono app is created in `apps/api/src/index.ts`.
+- Security middleware (CORS, CSP, rate limiting, secure headers) is applied at
+  the app level using `hono/security-headers`, `hono/cors`, and `hono-rate-limiter`.
+- tRPC is mounted via `@hono/trpc-server` at `/api/trpc`.
+- Better Auth routes are mounted at `/api/auth` using Better Auth's Hono handler.
+- Health and readiness endpoints are plain Hono routes.
+- The app is exported as a named export so it can be tested with `@hono/testing`
+  without starting a real server.
+
+## Alternatives Considered
+
+**Express**
+Express is the most widely known Node.js framework and has the largest ecosystem.
+However:
+
+- TypeScript support is via `@types/express`, not native. Request/response types
+  require manual augmentation for middleware-injected properties.
+- Express does not implement the Web Fetch API (`Request`/`Response`). Running on
+  edge runtimes or Bun requires a compatibility layer.
+- Middleware model is callback-based (`(req, res, next)`), which does not compose
+  as cleanly with async/await as Hono's handler model.
+- Express 5 addressed some of these issues but adoption is still low at the time
+  of decision.
+
+**Fastify**
+Fastify has excellent performance, a plugin system, and good TypeScript support via
+schemas. However:
+
+- Its plugin/decorator model is more complex than Hono's for small APIs.
+- It does not implement the Web Fetch API natively.
+- The schema-based validation (JSON Schema) duplicates Zod validation already
+  present in tRPC.
+
+**Elysia**
+Elysia is Bun-first, fast, and has a TypeScript-native API. At the time of decision,
+Node.js support was experimental and the ecosystem was immature. Revisit if Bun
+becomes the primary runtime.
+
+**Koa**
+More modern than Express but smaller ecosystem, no Web Fetch API support, and
+effectively superseded by Hono for new projects.
+
+## Consequences
+
+**Positive:**
+
+- Hono handlers use the Web Fetch API (`Request`/`Response`). Migrating to an edge
+  runtime requires changing only the entry point, not the application code.
+- TypeScript types are first-class; no `@types` package required.
+- The `c.get()` / `c.set()` context pattern is cleaner than Express
+  `req.locals` augmentation for middleware-injected values.
+- Testing is straightforward: pass a `Request` object, receive a `Response`.
+  No HTTP server required.
+- `hono/security-headers` covers most security header requirements out of the box.
+
+**Negative:**
+
+- Hono's ecosystem is smaller than Express. Some Express middleware has no Hono
+  equivalent and must be reimplemented.
+- Edge runtime compatibility is a future benefit, not a current requirement.
+  The abstraction cost is paid now for uncertain future value.
+- Less community documentation and fewer Stack Overflow answers than Express.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,146 @@
+# Error Handling
+
+Voiler uses **neverthrow** for all fallible operations. `throw`/`try-catch` is forbidden for business logic. Errors are values, not exceptions.
+
+## Core Principle
+
+Every function that can fail returns `Result<T, E>` (sync) or `ResultAsync<T, E>` (async). Consumers handle both paths explicitly via `.match()`.
+
+## DomainError -- Tagged Union
+
+Domain errors are a discriminated union with a `tag` for exhaustive pattern matching:
+
+```typescript
+// packages/domain/src/errors/domain-error.ts
+export type DomainError =
+  | { readonly tag: 'InvalidEmail'; readonly message: string }
+  | { readonly tag: 'InvalidPassword'; readonly message: string }
+  | { readonly tag: 'InvalidUserId'; readonly message: string }
+  | { readonly tag: 'WeakPassword'; readonly message: string }
+  | { readonly tag: 'UserNotFound'; readonly message: string }
+  | { readonly tag: 'UserAlreadyExists'; readonly message: string }
+```
+
+Factory functions create each variant:
+
+```typescript
+export const invalidEmail: (message: string) => DomainError = (message) => ({
+  tag: 'InvalidEmail',
+  message,
+})
+```
+
+## AppError -- Extended Union
+
+The core layer extends `DomainError` with infrastructure and validation variants:
+
+```typescript
+// packages/core/src/errors/app-error.ts
+export type AppError = DomainError | InfrastructureError | ValidationError
+
+export interface InfrastructureError {
+  readonly tag: 'InfrastructureError'
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export interface ValidationError {
+  readonly tag: 'ValidationError'
+  readonly message: string
+  readonly field?: string
+}
+```
+
+## Creating Results
+
+Value objects return `Result` (sync):
+
+```typescript
+export const createEmail: (params: CreateEmailParams) => Result<Email, DomainError> = (params) => {
+  const { value } = params
+  const trimmed: string = value.trim().toLowerCase()
+
+  if (!EMAIL_REGEX.test(trimmed)) {
+    return err(invalidEmail('Invalid email address format'))
+  }
+
+  return ok(trimmed as Email)
+}
+```
+
+Repository ports return `ResultAsync` (async):
+
+```typescript
+export interface IUserRepository {
+  create: (params: { data: CreateUserData }) => ResultAsync<UserEntity, AppError>
+  findById: (params: { id: string }) => ResultAsync<UserEntity | null, AppError>
+}
+```
+
+## Consuming Results with `.match()`
+
+tRPC procedures use `.match()` for exhaustive handling:
+
+```typescript
+const result = await createUser({ name: opts.input.name, email: opts.input.email })
+
+return result.match(
+  (entity) => mapToPublicUser({ entity }),
+  (error) => throwTrpcError({ error }),
+)
+```
+
+## Exhaustive Error Mapping
+
+Map error tags to tRPC codes with a `switch` and `never` guard:
+
+```typescript
+const mapErrorCode: (params: { tag: AppError['tag'] }) => TRPCError['code'] = (params) => {
+  switch (params.tag) {
+    case 'UserNotFound':
+      return 'NOT_FOUND'
+    case 'UserAlreadyExists':
+      return 'CONFLICT'
+    case 'InvalidEmail':
+    case 'InvalidPassword':
+    case 'InvalidUserId':
+    case 'WeakPassword':
+    case 'ValidationError':
+      return 'BAD_REQUEST'
+    case 'InfrastructureError':
+      return 'INTERNAL_SERVER_ERROR'
+    default: {
+      const _exhaustive: never = params.tag
+      return _exhaustive
+    }
+  }
+}
+```
+
+## Sanitizing Errors
+
+Never leak infrastructure details to the client:
+
+```typescript
+const message: string =
+  params.error.tag === 'InfrastructureError' ? 'Internal server error' : params.error.message
+```
+
+## What NOT to Do
+
+```typescript
+// FORBIDDEN -- throw in business logic
+const createUser = (params) => {
+  if (!valid) throw new Error('Invalid')
+  // ...
+}
+
+// FORBIDDEN -- try-catch for flow control
+try {
+  const user = await getUser(id)
+} catch (e) {
+  // ...
+}
+```
+
+The only place `throw` appears is in tRPC error boundaries (converting `AppError` to `TRPCError` at the adapter layer) and Better Auth admin procedures (which wrap external SDK calls).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,128 @@
+# Observability
+
+Voiler uses structured JSON logging, audit trails, and health checks for production observability.
+
+## Structured Request Logging
+
+Every request gets a unique ID and structured JSON logs at start and completion:
+
+```typescript
+// apps/api/src/logging/request-logger.ts
+const requestLogger: () => MiddlewareHandler = () => {
+  return async (c, next) => {
+    const requestId: string = crypto.randomUUID()
+    c.set('requestId', requestId)
+
+    // Log: { level, event: "request.start", requestId, method, path, timestamp }
+    await next()
+    // Log: { level, event: "request.complete", requestId, method, path, status, durationMs }
+  }
+}
+```
+
+The `requestId` propagates through the entire request lifecycle -- tRPC context, use cases, and audit logs all reference it.
+
+## Log Format
+
+All logs are JSON written to `stderr` via `console.warn` (or `console.error` for errors):
+
+```json
+{
+  "level": "info",
+  "event": "request.complete",
+  "requestId": "550e8400-e29b-41d4-a716-446655440000",
+  "method": "POST",
+  "path": "/trpc/user.create",
+  "status": 200,
+  "durationMs": 42
+}
+```
+
+## Use Case Logger
+
+The `withAuditLog` wrapper adds structured logging and audit trails to use cases:
+
+```typescript
+// apps/api/src/logging/use-case-logger.ts
+const createUser = withAuditLog({
+  name: 'user.create',
+  useCase: rawCreateUser,
+  getEntityId: (result) => String(result.id),
+  db,
+})
+```
+
+This produces three events per use case call:
+
+1. `use-case.start` -- before execution (info)
+2. `use-case.success` -- after success, writes audit log (info)
+3. `use-case.failure` -- after failure (error)
+
+## Audit Log
+
+Audit log entries are persisted to PostgreSQL via the `AuditLog` table:
+
+```typescript
+interface AuditLogEntry {
+  readonly requestId: string
+  readonly action: string // e.g., 'user.create', 'admin.impersonate'
+  readonly userId?: string // Who performed the action
+  readonly entityId?: string // What was affected
+  readonly metadata?: Record<string, unknown>
+}
+```
+
+Two write modes:
+
+- `writeAuditLog` -- fire-and-forget (non-blocking, for regular use cases)
+- `writeAuditLogAsync` -- awaited (for critical actions like impersonation)
+
+## Audit Log Cleanup
+
+Old audit entries are pruned on server startup (default: 30-day retention):
+
+```typescript
+// apps/api/src/logging/cleanup.ts
+const cleanupAuditLog: (params: CleanupAuditLogParams) => Promise<void> = async (params) => {
+  const ageDays: number = maxAgeDays ?? DEFAULT_MAX_AGE_DAYS // 30
+  const cutoffDate: Date = new Date(Date.now() - ageDays * MS_PER_DAY)
+  await db.delete(AuditLog).where(lt(AuditLog.createdAt, cutoffDate))
+}
+```
+
+Runs as fire-and-forget on server boot:
+
+```typescript
+void cleanupAuditLog({ db }).catch((cleanupErr: unknown) => {
+  console.error('[api] Audit log cleanup failed:', cleanupErr)
+})
+```
+
+## Health Check
+
+`GET /health` returns server status, uptime, and database connectivity:
+
+```typescript
+// apps/api/src/http/health.ts
+interface HealthResponse {
+  status: 'ok' | 'error'
+  uptime: number // seconds
+  db: 'connected' | 'disconnected'
+  timestamp: string // ISO 8601
+}
+```
+
+Returns `200` when DB is connected, `503` when disconnected.
+
+## Middleware Stack Order
+
+Middleware order in `apps/api/src/index.ts` matters:
+
+| Order | Middleware       | Purpose                          |
+| ----- | ---------------- | -------------------------------- |
+| 1     | Rate limiter     | Reject abusive IPs early         |
+| 2     | Request logger   | Assign request ID, log start/end |
+| 3     | Security headers | HSTS, CSP, X-Frame-Options       |
+| 4     | CORS             | Validate origin                  |
+| 5     | CSRF             | Validate origin on mutations     |
+| 6     | Body limit       | Reject payloads > 1 MB           |

--- a/docs/project-mgmt.md
+++ b/docs/project-mgmt.md
@@ -1,0 +1,121 @@
+# Project Management
+
+Workflow for GitHub Issues, pull requests, and code review in Voiler.
+
+## GitHub Issues
+
+Issues track all planned work. Each issue has a clear title, description, and acceptance criteria.
+
+### Labels
+
+| Label      | Use                                                  |
+| ---------- | ---------------------------------------------------- |
+| `feat`     | New feature or capability                            |
+| `fix`      | Bug fix                                              |
+| `refactor` | Code improvement without behavior change             |
+| `docs`     | Documentation only                                   |
+| `test`     | Test additions or improvements                       |
+| `chore`    | Tooling, CI, dependencies                            |
+| `plan-X`   | Tracks which implementation plan the work belongs to |
+
+### Issue Template
+
+- Title: concise description of the deliverable
+- Body: context, acceptance criteria, related plan reference
+- Labels: at least one type label + plan label if applicable
+
+## Branch Naming
+
+```
+feat/plan-X-short-description
+fix/issue-number-short-description
+docs/plan-X-short-description
+```
+
+Examples: `feat/plan-a-foundation`, `fix/42-email-validation`, `docs/plan-f-docs`.
+
+## Pull Request Process
+
+1. Create a branch from `main`
+2. Implement changes with commits following conventional style
+3. Run full verification before opening PR:
+   - `pnpm lint` -- 0 errors
+   - `pnpm typecheck` -- 0 errors
+   - `pnpm test` -- all passing
+   - `pnpm format:check` -- all formatted
+4. Open PR with summary and test plan
+5. PR gets double-agent review (see below)
+6. Squash-merge to `main`
+
+### PR Title Format
+
+```
+type(scope): short description
+```
+
+Examples:
+
+- `feat(plan-a): implement Hono server with security middleware`
+- `fix(auth): correct cookie prefix in production`
+- `docs(plan-f): add documentation hub and detail docs`
+
+### PR Body Template
+
+```markdown
+## Summary
+
+- Bullet points describing what changed and why
+
+## Test plan
+
+- [ ] Unit tests pass
+- [ ] E2E tests pass (if runtime code changed)
+- [ ] Lint and typecheck clean
+```
+
+## Code Review -- Double-Agent Process
+
+Every PR gets reviewed by two AI agents with different perspectives:
+
+1. **Strict Reviewer** -- focuses on correctness, security, architecture compliance, and edge cases. Flags anything that violates the coding mandates.
+
+2. **Pragmatic Triager** -- evaluates the strict reviewer's findings. Separates genuine issues from false positives and nitpicks. Prioritizes findings by severity.
+
+This catches real issues while avoiding review fatigue from pedantic feedback.
+
+### Review Checklist
+
+- [ ] No `any` or `as` casting (except branded types)
+- [ ] No semicolons
+- [ ] Arrow functions with max 1 param
+- [ ] `Result`/`ResultAsync` for fallible functions
+- [ ] No `throw`/`try-catch` in business logic
+- [ ] JSDoc on all exports
+- [ ] Domain layer has zero infra imports
+- [ ] tRPC routers are thin (parse, call, return)
+- [ ] Infrastructure errors sanitized before client response
+
+## Commit Style
+
+```
+type(scope): description
+
+Co-Authored-By: Agent Name <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+
+## Plan Execution
+
+Implementation follows numbered plans in `docs/superpowers/plans/`. Each plan:
+
+- Has a spec defining contracts and deliverables
+- Is executed in a dedicated branch (`feat/plan-X-...`)
+- Gets a PR with full verification
+- Is tracked by plan label on issues
+
+Current plans:
+
+- Plan A: Foundation (completed)
+- Plan B: Auth + sessions (completed)
+- Plans C+: See `docs/superpowers/plans/` for details

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,131 @@
+# Testing
+
+Voiler uses **Vitest** for unit tests and **Playwright** for E2E tests.
+
+## Test Locations
+
+| Package            | Test directory   | What to test                             |
+| ------------------ | ---------------- | ---------------------------------------- |
+| `packages/domain/` | `src/__tests__/` | Value objects, domain error constructors |
+| `apps/api/`        | `src/__tests__/` | Use cases, tRPC guards, error mapping    |
+| `apps/web/`        | `e2e/`           | Full user flows (Playwright)             |
+
+## Running Tests
+
+```bash
+pnpm test              # Run all Vitest unit tests (all packages)
+pnpm test:e2e          # Run Playwright E2E (requires dev server running)
+```
+
+## Vitest Configuration
+
+The project uses a Vitest workspace at the root that discovers all packages:
+
+```
+vitest.workspace.ts    # Root workspace config
+apps/api/vitest.config.ts
+packages/domain/vitest.config.ts
+```
+
+## Writing Unit Tests
+
+### Use Case Tests
+
+Use cases are tested by mocking the repository port:
+
+```typescript
+import { errAsync, okAsync } from 'neverthrow'
+import { describe, it, expect, vi } from 'vitest'
+
+const makeMockRepo = (): IUserRepository => ({
+  create: vi.fn(),
+  findAll: vi.fn(),
+  findById: vi.fn(),
+  findByEmail: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+})
+
+describe('createUser use case', () => {
+  it('returns Ok(UserEntity) on happy path', async () => {
+    const fakeUser = makeFakeUser()
+    const repo = makeMockRepo()
+    vi.mocked(repo.create).mockReturnValue(okAsync(fakeUser))
+
+    const useCase = createCreateUser({ userRepository: repo })
+    const result = await useCase({ name: 'Test User', email: 'test@example.com' })
+
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toEqual(fakeUser)
+    }
+  })
+
+  it('returns Err when repository create fails', async () => {
+    const repo = makeMockRepo()
+    const repoError: AppError = infrastructureError({ message: 'db error' })
+    vi.mocked(repo.create).mockReturnValue(errAsync(repoError))
+
+    const useCase = createCreateUser({ userRepository: repo })
+    const result = await useCase({ name: 'Test', email: 'test@example.com' })
+
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.tag).toBe('InfrastructureError')
+    }
+  })
+})
+```
+
+### Domain Tests
+
+Domain error constructors and value objects are tested for correct tag/message:
+
+```typescript
+describe('DomainError constructors', () => {
+  it('invalidEmail creates correct tag and message', () => {
+    const error = invalidEmail('bad email')
+    expect(error.tag).toBe('InvalidEmail')
+    expect(error.message).toBe('bad email')
+  })
+})
+```
+
+## Test Patterns
+
+| Pattern                         | Description                                                     |
+| ------------------------------- | --------------------------------------------------------------- |
+| Mock ports, not implementations | Use `vi.fn()` to stub `IUserRepository` methods                 |
+| Test both paths                 | Always test `Ok` and `Err` branches                             |
+| Use `isOk()` / `isErr()` guards | Narrow the result type before asserting on `.value` or `.error` |
+| Factory helpers                 | Create `makeFakeUser()` and `makeMockRepo()` helpers            |
+| No DB in unit tests             | Unit tests never touch the database                             |
+
+## TDD Workflow
+
+1. Write a failing test for the new behavior
+2. Implement the minimum code to pass
+3. Refactor while keeping tests green
+4. Run `pnpm test` to verify
+
+## E2E Tests (Playwright)
+
+E2E tests live in `apps/web/e2e/` and test full user flows through the browser. They require the dev server to be running:
+
+```bash
+# Terminal 1
+docker compose up db -d
+pnpm --filter @voiler/api dev
+
+# Terminal 2
+pnpm test:e2e
+```
+
+## Verification Checklist
+
+After every task:
+
+1. `pnpm test` -- all unit tests passing
+2. `pnpm test:e2e` -- if runtime code changed
+3. `pnpm lint` -- 0 errors
+4. `pnpm typecheck` -- 0 errors

--- a/packages/config-env/CLAUDE.md
+++ b/packages/config-env/CLAUDE.md
@@ -1,0 +1,29 @@
+# @voiler/config-env
+
+Zod-validated environment configuration with fail-fast behavior. Validates all required env vars at startup.
+
+## Key Files
+
+| File              | Purpose                                           |
+| ----------------- | ------------------------------------------------- |
+| `src/schema.ts`   | Zod schema defining all env vars (EnvConfig type) |
+| `src/load-env.ts` | Loads .env, validates, exits on failure           |
+
+## Usage
+
+```typescript
+import { loadEnv } from '@voiler/config-env'
+const env = loadEnv()
+// env.PORT, env.DATABASE_URL, env.AUTH_SECRET, etc.
+```
+
+## Rules
+
+- If any required env var is missing or malformed, the process exits immediately.
+- All env vars are typed via Zod inference -- no manual type definitions.
+
+## Commands
+
+```bash
+pnpm --filter @voiler/config-env typecheck   # Type check
+```

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,0 +1,24 @@
+# @voiler/core
+
+Core layer -- port interfaces and application error union. Depends only on `@voiler/domain` and `neverthrow`.
+
+## Key Files
+
+| File                                  | Purpose                                                              |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `src/errors/app-error.ts`             | AppError union (DomainError + InfrastructureError + ValidationError) |
+| `src/repositories/user.repository.ts` | IUserRepository port interface                                       |
+
+## Rules
+
+- Defines **port interfaces** that adapters implement.
+- Never imports concrete implementations (DB drivers, HTTP clients).
+- All repository methods return `ResultAsync<T, AppError>`.
+
+## Commands
+
+```bash
+pnpm --filter @voiler/core typecheck   # Type check
+```
+
+See [../../docs/architecture.md] and [../../docs/error-handling.md].

--- a/packages/domain/CLAUDE.md
+++ b/packages/domain/CLAUDE.md
@@ -1,0 +1,30 @@
+# @voiler/domain
+
+Pure domain layer -- entities, value objects, and domain errors. **Zero infrastructure dependencies.**
+
+## Key Files
+
+| File                            | Purpose                                      |
+| ------------------------------- | -------------------------------------------- |
+| `src/entities/user.ts`          | UserEntity type, UserRole                    |
+| `src/value-objects/email.ts`    | Email branded type with validation           |
+| `src/value-objects/password.ts` | Password branded type with strength rules    |
+| `src/value-objects/user-id.ts`  | UserId branded type                          |
+| `src/errors/domain-error.ts`    | DomainError tagged union + factory functions |
+| `src/types/brand.ts`            | Brand utility type                           |
+| `src/__tests__/`                | Unit tests for errors and value objects      |
+
+## Rules
+
+- This package must NEVER import infrastructure (DB, HTTP, etc.).
+- Only depends on `neverthrow` for Result types.
+- All value objects return `Result<T, DomainError>`.
+
+## Commands
+
+```bash
+pnpm --filter @voiler/domain test      # Unit tests
+pnpm --filter @voiler/domain typecheck # Type check
+```
+
+See [../../docs/architecture.md] and [../../docs/error-handling.md].

--- a/packages/schema/CLAUDE.md
+++ b/packages/schema/CLAUDE.md
@@ -1,0 +1,28 @@
+# @voiler/schema
+
+Single source of truth for all database tables and validation schemas. Drizzle owns table definitions, Zod owns validation rules.
+
+## Key Files
+
+| File                         | Purpose                                                    |
+| ---------------------------- | ---------------------------------------------------------- |
+| `src/entities/user.ts`       | User table (Drizzle) + select/insert schemas (drizzle-zod) |
+| `src/entities/auth.ts`       | Session, Account, Verification tables (Better Auth)        |
+| `src/entities/audit-log.ts`  | AuditLog table                                             |
+| `src/inputs/create-user.ts`  | CreateUserInputSchema (tRPC input validation)              |
+| `src/inputs/update-user.ts`  | UpdateUserInputSchema                                      |
+| `src/inputs/pagination.ts`   | PaginationInputSchema                                      |
+| `src/outputs/public-user.ts` | PublicUser schema (client-safe response)                   |
+
+## Rules
+
+- Types are inferred from schemas -- never manually defined.
+- Shared by both API (Drizzle queries) and frontend (Zod validation).
+
+## Commands
+
+```bash
+pnpm --filter @voiler/schema typecheck   # Type check
+```
+
+See [../../docs/architecture.md].


### PR DESCRIPTION
## Summary

- CLAUDE.md rewritten as navigation hub (< 80 lines)
- GEMINI.md symlink
- 7 detail docs: architecture, code-standards, error-handling, auth, testing, observability, project-mgmt
- 6 ADRs: hexagonal, neverthrow, zod, tRPC, better-auth, hono
- 6 agent role files in _agents/
- 6 per-package CLAUDE.md guides

## Test plan

- [ ] All doc links in CLAUDE.md resolve
- [ ] `pnpm lint` / `pnpm typecheck` / `pnpm format:check` pass